### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "A simple utility for creating an object with values equal to its keys. Identical to react/lib/keyMirror",
   "main": "index.js",
   "author": "Samuel Reed <sam@tixelated.com> (http://strml.net/)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/STRML/keyMirror"
+  },
   "licenses": [
     {
       "type": "Apache-2.0",


### PR DESCRIPTION
This will stop warnings when installing via npm and add a link to the GitHub repo on the npm package page.
