### PR TITLE
Accept arrays of strings as input and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Input:  `{key1: val1, key2: val2}`
 
 Output: `{key1: key1, key2: key2}`
 
+Input:  `[key1, key2]`
+
+Output: `{key1: key1, key2: key2}`
+
 I sometimes use this with lodash - use the following upon your first use of lodash to mix it in:
 
 ```javascript

--- a/index.js
+++ b/index.js
@@ -17,6 +17,10 @@
 
 "use strict";
 
+var isString = function(s) {
+  return typeof(s) === 'string' || s instanceof String;
+}
+
 /**
  * Constructs an enumeration with keys equal to their value.
  *
@@ -32,18 +36,31 @@
  *   Input:  {key1: val1, key2: val2}
  *   Output: {key1: key1, key2: key2}
  *
- * @param {object} obj
+ *   Input:  [key1, key2]
+ *   Output: {key1: key1, key2: key2}
+ *
+ * @param {(object|string[])} obj
  * @return {object}
  */
 var keyMirror = function(obj) {
   var ret = {};
   var key;
-  if (!(obj instanceof Object && !Array.isArray(obj))) {
-    throw new Error('keyMirror(...): Argument must be an object.');
+  if (!(obj instanceof Object)) {
+    throw new Error('keyMirror(...): Argument must be an object or an array.');
   }
-  for (key in obj) {
-    if (obj.hasOwnProperty(key)) {
+  if (Array.isArray(obj)) {
+    for (var i = 0; i < obj.length; i++) {
+      key = obj[i];
+      if (!(isString(key))) {
+        throw new Error('keyMirror(...): Keys must be strings.');
+      }
       ret[key] = key;
+    };
+  } else {
+    for (key in obj) {
+      if (obj.hasOwnProperty(key)) {
+        ret[key] = key;
+      }
     }
   }
   return ret;

--- a/package.json
+++ b/package.json
@@ -13,5 +13,12 @@
       "type": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0"
     }
-  ]
+  ],
+  "devDependencies": {
+    "chai": "^2.3.0",
+    "mocha": "^2.2.4"
+  },
+  "scripts": {
+    "test": "mocha -R spec tests.js"
+  }
 }

--- a/tests.js
+++ b/tests.js
@@ -1,0 +1,80 @@
+var chai = require('chai');
+    expect = chai.expect,
+
+    keyMirror = require('./index.js');
+
+describe('keyMirror', function() {
+
+  describe('with object input', function() {
+    var map = null;
+    before(function() {
+      map = keyMirror({a: null, b: undefined, c: 'something', 'd': null});
+    });
+
+    it('should accept objects with null values', function() {
+      expect(map.a).to.equal('a');
+    });
+
+    it('should accept objects with undefined values', function() {
+      expect(map.b).to.equal('b');
+    });
+
+    it('should accept objects with string values', function() {
+      expect(map.c).to.equal('c');
+    });
+
+    it('should accept objects with string keys', function() {
+      expect(map.d).to.equal('d');
+    });
+  });
+
+  describe('with array input', function() {
+    var map = null;
+    before(function() {
+      map = keyMirror(['a', 'b', 'c']);
+    });
+
+    it('should accept an array of strings', function() {
+      expect(map.a).to.equal('a');
+    });
+
+  });
+
+  describe('error handling', function() {
+    var invokeWith = function(arg) {
+      return function() { return keyMirror(arg) };
+    }
+
+    it('should not accept null', function() {
+      expect(invokeWith(null)).to.throw();
+    });
+
+    it('should not accept undefined', function() {
+      expect(invokeWith(undefined)).to.throw();
+    });
+
+    it('should not accept numbers', function() {
+      expect(invokeWith(1)).to.throw();
+    });
+
+    it('should not accept strings', function() {
+      expect(invokeWith('string')).to.throw();
+    });
+
+    it('should accept empty objects', function() {
+      expect(invokeWith({})).to.not.throw();
+    });
+
+    it('should accept empty arrays', function() {
+      expect(invokeWith([])).to.not.throw();
+    });
+
+    it('should not accept null in an array', function() {
+      expect(invokeWith(['a', null])).to.throw();
+    });
+
+    it('should not accept undefined in an array', function() {
+      expect(invokeWith(['a', undefined])).to.throw();
+    });
+  })
+});


### PR DESCRIPTION
Fancy accepting arrays of strings as input, e.g. `map = keyMirror(['blue', 'red'])`?

To me this feels less verbose than `map = keyMirror({blue: null, red: null})` but that's just personal preference.

I understand if this is unnecessary bloat for such a small and elegant library :)

I also added a small test suite just to sanity check my changes.