### PR TITLE
add support for passing arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Input:  `{key1: val1, key2: val2}`
 
 Output: `{key1: key1, key2: key2}`
 
+If you prefer passing an Array to keyMirror, this: `keyMirror(['blue', 'red'])` is equivalent to `keyMirror({blue: null, red: null})`.
+
 I sometimes use this with lodash - use the following upon your first use of lodash to mix it in:
 
 ```javascript

--- a/index.js
+++ b/index.js
@@ -18,6 +18,37 @@
 "use strict";
 
 /**
+ * Constructs an enumeration with keys equal to their value from an Object.
+ *
+ * @param {object} obj
+ * @return {object}
+ */
+function mirrorObject(obj) {
+  var ret = {};
+  for (var key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      ret[key] = key;
+    }
+  }
+  return ret;
+}
+
+/**
+ * Constructs an enumeration with keys equal to their value from an Array.
+ *
+ * @param {array} arr
+ * @return {object}
+ */
+function mirrorArray(arr) {
+  var ret = {};
+  for (var i = 0; i < arr.length; i++) {
+    var key = arr[i];
+    ret[key] = key;
+  }
+  return ret;
+}
+
+/**
  * Constructs an enumeration with keys equal to their value.
  *
  * For example:
@@ -32,21 +63,26 @@
  *   Input:  {key1: val1, key2: val2}
  *   Output: {key1: key1, key2: key2}
  *
- * @param {object} obj
+ * Example with arrays:
+ * 
+ *   var COLORS = keyMirror(['blue', 'red']);
+ *   var myColor = COLORS.blue;
+ *   var isColorValid = !!COLORS[myColor];
+ *
+ *   Input:  ['key1', 'key2']
+ *   Output: {key1: key1, key2: key2}
+ * 
+ * @param {object|array} input
  * @return {object}
  */
-var keyMirror = function(obj) {
-  var ret = {};
-  var key;
-  if (!(obj instanceof Object && !Array.isArray(obj))) {
-    throw new Error('keyMirror(...): Argument must be an object.');
+function keyMirror(input) {
+  if (Array.isArray(input)) {
+    return mirrorArray(input);
+  } else if (input instanceof Object) {
+    return mirrorObject(input);
+  } else {
+    throw new Error('keyMirror(...): Argument must be an object or array.');
   }
-  for (key in obj) {
-    if (obj.hasOwnProperty(key)) {
-      ret[key] = key;
-    }
-  }
-  return ret;
 };
 
 module.exports = keyMirror;


### PR DESCRIPTION
this `keyMirror({blue: null, red: null})` is equivalent to `keyMirror(['blue', 'red'])` now

having to write the `null`s is redundant and makes the code longer when it doesn't need to be (if you don't use `lodash`)
