### PR TITLE
Added licence field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/STRML/keyMirror"
-  },
-  "licenses": [
-    {
-      "type": "Apache-2.0",
-      "url": "http://www.apache.org/licenses/LICENSE-2.0"
-    }
-  ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "keymirror",
   "version": "0.1.1",
+  "license": "Apache-2.0",
   "description": "A simple utility for creating an object with values equal to its keys. Identical to react/lib/keyMirror",
   "main": "index.js",
   "author": "Samuel Reed <sam@tixelated.com> (http://strml.net/)",


### PR DESCRIPTION
Licences is deprecated I belive. Doesn't hurt to have both.