### PR TITLE
Optional parameter to enable users to provide custom values for keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,42 @@ var _ = require('lodash');
 _.mixin({keyMirror: require('keymirror')});
 // Can now be used as _.keyMirror(object)
 ```
+
+
+
+Optional Parameter
+----
+
+```javascript
+{ useCustomValue: true }
+```
+
+Idea is to provide users to provide custom values for some of the keys
+(specifically when you want to have keys different than the values)
+and tell the keyMirror to mirror only keys with value as null.
+
+
+```javascript
+var keyMirror = require('keymirror');
+var AppConstants = keyMirror({
+    a: null,
+    b: null,
+    jsPath: '../js/',
+    colors: keyMirror({
+        blue: null,
+        red: 'darkred'
+    }, { useCustomValue: true })
+}, {
+    useCustomValue: true
+});
+
+console.log(AppConstants.a); // Output: a
+console.log(AppConstants.b); // Output: b
+console.log(AppConstants.jsPath); // Output: ../js/ -> custom value being used
+console.log(AppConstants.colors.blue); // Output: blue
+console.log(AppConstants.colors.red); // Output: darkred -> custom value being used
+
+// Even AppConstants.colors is defined with custom value,
+// and this allows us to build complex JSON objects with few mirrored values and few custom values
+
+```

--- a/index.js
+++ b/index.js
@@ -33,9 +33,10 @@
  *   Output: {key1: key1, key2: key2}
  *
  * @param {object} obj
+ * @param {object} opts
  * @return {object}
  */
-var keyMirror = function(obj) {
+var keyMirror = function(obj, opts) {
   var ret = {};
   var key;
   if (!(obj instanceof Object && !Array.isArray(obj))) {
@@ -43,7 +44,13 @@ var keyMirror = function(obj) {
   }
   for (key in obj) {
     if (obj.hasOwnProperty(key)) {
-      ret[key] = key;
+      var objVal = obj[key];
+      if(opts && opts.useCustomValue === true && objVal) {
+        ret[key] = objVal;
+      }
+      else {
+        ret[key] = key;
+      }
     }
   }
   return ret;


### PR DESCRIPTION
## Optional Parameter

``` javascript
{ useCustomValue: true }
```

Idea is to provide users to provide custom values for some of the keys
(specifically when you want to have keys different than the values)
and tell the keyMirror to mirror only keys with value as null.

``` javascript
var keyMirror = require('keymirror');
var AppConstants = keyMirror({
    a: null,
    b: null,
    jsPath: '../js/',
    colors: keyMirror({
        blue: null,
        red: 'darkred'
    }, { useCustomValue: true })
}, {
    useCustomValue: true
});

console.log(AppConstants.a); // Output: a
console.log(AppConstants.b); // Output: b
console.log(AppConstants.jsPath); // Output: ../js/ -> custom value being used
console.log(AppConstants.colors.blue); // Output: blue
console.log(AppConstants.colors.red); // Output: darkred -> custom value being used

// Even AppConstants.colors is defined with custom value,
// and this allows us to build complex JSON objects with few mirrored values and few custom values

```
